### PR TITLE
fixed node sorting in DAG.get_v_structures()

### DIFF
--- a/baynet/structure.py
+++ b/baynet/structure.py
@@ -232,7 +232,7 @@ class DAG(igraph.Graph):
         for node in self.nodes:
             all_parents = self.get_ancestors(node, only_parents=True)
             all_pairs = combinations(all_parents, 2)
-            all_pairs = [sorted(pair) for pair in all_pairs]
+            all_pairs = [sorted(pair, key=lambda x: x['name']) for pair in all_pairs]
             if include_shielded:
                 node_v_structures = [(a["name"], node, b["name"]) for a, b in all_pairs]
             else:

--- a/tests/test_structure.py
+++ b/tests/test_structure.py
@@ -202,6 +202,12 @@ def test_DAG_get_v_structures(test_dag, reversed_dag, partial_dag):
     assert dag.get_v_structures(True) == {("C", "B", "D")}
     assert reversed_dag.get_v_structures(True) == {("B", "D", "C")}
 
+    # Test node order doesn't change V-structure tuple order
+    other_dag = DAG()
+    other_dag.add_vertices(list("DCBA"))
+    other_dag.add_edges([("C", "B"), ("D", "B"), ("D", "C")])
+    assert other_dag.get_v_structures(True) == dag.get_v_structures(True)
+
 
 def test_DAG_serialise_continuous_file(temp_out, test_dag):
     dag_path = temp_out / 'cont.pb'


### PR DESCRIPTION
V-structure tuples (of form `(parent_1, child, parent_2)`) occasionally differed for the same V-structure, as the ordering of `parent_1` and `parent_2` depended on the order in which they were added to the graph, rather than by something constant (i.e. name). This fixes that by sorting by `name` attribute.