### PR TITLE
Fix param sampling

### DIFF
--- a/baynet/structure.py
+++ b/baynet/structure.py
@@ -291,9 +291,11 @@ class DAG(igraph.Graph):
             self.vs["levels"]
         except KeyError:
             self.generate_levels(min_levels, max_levels, seed)
+        if seed is not None:
+            np.random.seed(seed)
         for vertex in self.vs:
             vertex["CPD"] = ConditionalProbabilityTable(vertex)
-            vertex["CPD"].sample_parameters(alpha=alpha, seed=seed)
+            vertex["CPD"].sample_parameters(alpha=alpha)
 
     def estimate_parameters(
         self,

--- a/tests/test_structure.py
+++ b/tests/test_structure.py
@@ -262,11 +262,12 @@ def test_DAG_generate_parameters(test_dag):
 
     for levels in [["0", "1"], ["0", "1", "2"]]:
         dag.vs['levels'] = [levels for v in dag.vs]
-        dag.generate_discrete_parameters()
+        dag.generate_discrete_parameters(seed=0)
         assert dag.vs[0]['CPD'].array.shape == (len(levels),)
         assert dag.vs[1]['CPD'].array.shape == (len(levels), len(levels), len(levels))
         assert dag.vs[2]['CPD'].array.shape == (len(levels), len(levels))
         assert dag.vs[3]['CPD'].array.shape == (len(levels),)
+        assert not np.allclose(dag.vs[0]['CPD'].array, dag.vs[3]['CPD'].array)
 
 
 def test_DAG_estimate_parameters(test_dag):


### PR DESCRIPTION
Fixed a lil bug in parameter sampling with a seed set, it was being set again for each node leading to repeated CPTs. As far as I know this has never been used, so it shouldn't have caused any problems.